### PR TITLE
WIP: Fix inclusion of certificate files

### DIFF
--- a/statuspage.py
+++ b/statuspage.py
@@ -11,6 +11,11 @@ from tqdm import tqdm
 
 __version__ = "0.2"
 
+
+# Load certificate file.
+if getattr(sys, 'frozen', False):
+    os.environ['SSL_CERT_FILE'] = os.path.join(sys._MEIPASS, 'lib', 'cert.pem')
+
 try:
     ROOT = sys._MEIPASS
 except AttributeError:

--- a/statuspage.spec
+++ b/statuspage.spec
@@ -1,12 +1,22 @@
 # -*- mode: python -*-
 
+
+from PyInstaller.utils.hooks.hookutils import exec_statement
+
+# Collect certificate files.
+cert_datas = exec_statement("""
+    import ssl
+    print(ssl.get_default_verify_paths().cafile)""").strip().split()
+cert_datas = [(f, 'lib'), for f in cert_datas)
+
+
 block_cipher = None
 
 
 a = Analysis(['statuspage.py'],
              pathex=['.'],
              binaries=None,
-             datas=None,
+             datas=cert_datas,
              hiddenimports=[],
              hookspath=[],
              runtime_hooks=[],


### PR DESCRIPTION
Currently, it appears the certificate files are not included when building the binaries. As a result, if one tries to run an operation like create, this will fail (traceback shown below).

```
Traceback (most recent call last):
  File "statuspage.py", line 193, in <module>
  File "site-packages/click/core.py", line 716, in __call__
  File "site-packages/click/core.py", line 696, in main
  File "site-packages/click/core.py", line 1060, in invoke
  File "site-packages/click/core.py", line 889, in invoke
  File "site-packages/click/core.py", line 534, in invoke
  File "statuspage.py", line 46, in create
  File "statuspage.py", line 109, in run_create
  File "statuspage.py", line 180, in get_user_info
  File "site-packages/github/MainClass.py", line 188, in get_organization
  File "site-packages/github/Requester.py", line 171, in requestJsonAndCheck
  File "site-packages/github/Requester.py", line 212, in requestJson
  File "site-packages/github/Requester.py", line 251, in __requestEncode
  File "site-packages/github/Requester.py", line 275, in __requestRaw
  File "httplib.py", line 1057, in request
  File "httplib.py", line 1097, in _send_request
  File "httplib.py", line 1053, in endheaders
  File "httplib.py", line 897, in _send_output
  File "httplib.py", line 859, in send
  File "httplib.py", line 1278, in connect
  File "ssl.py", line 352, in wrap_socket
  File "ssl.py", line 579, in __init__
  File "ssl.py", line 808, in do_handshake
ssl.SSLError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:590)
Failed to execute script statuspage
```

To fix this, one needs to include the certificates in when building with PyInstaller. This is explained in PyInstaller's [wiki]( https://github.com/pyinstaller/pyinstaller/wiki/Recipe-OpenSSL-Certificate ). This PR just follows that recommendation to try and fix this.