### PR TITLE
Fix license trove classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         'Environment :: Console',
         'Intended Audience :: Developers',
         'Natural Language :: English',
-        'License :: OSI Approved :: BSD License',
+        'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',


### PR DESCRIPTION
Everything else suggests this is MIT. However, the trove classifier says BSD. This corrects that trove classifier to MIT as well.