### PR TITLE
Include the license

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include statuspage/template/*
 include README.md
 include CHANGELOG.md
+include LICENSE


### PR DESCRIPTION
Add the license file to `MANIFEST.in` to ensure it is included in the `sdist` or related packages.