### PR TITLE
Fix for issues not being marked as resolved

### DIFF
--- a/statuspage/statuspage.py
+++ b/statuspage/statuspage.py
@@ -389,7 +389,7 @@ def get_incidents(repo, issues):
         severity = get_severity(labels)
 
         # make sure that non-labeled issues are not displayed
-        if not affected_systems or severity is None:
+        if not affected_systems or (severity is None and issue.state != "closed"):
             continue
 
         # make sure that the user that created the issue is a collaborator


### PR DESCRIPTION
The "resolved" label is not in list of labels created by the system, so that caused
```python
if not affected_systems or severity is None:
```
to have `severity = None`, which basically made it ignore closed issues with no severity status (since you remove the label), after resolving an issue.

Now it works as intended. User removes severity label, closes the issue - statuspage generates proper resolved issue in the list.

This fix also avoids template render error stated in #96 